### PR TITLE
voxel-highlight 0.0.6 demo

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,15 @@ module.exports = function(opts) {
   substack.yaw.position.set(2, 14, 4)
 
   // highlight blocks when you look at them
-  var highlighter = highlight(game)
+  var highlighter = highlight(game, {
+    color: 0xff0000,
+    distance: 100,
+    frequency: 20 // very frequent for "painting" mode
+  })
+  highlighter.on('highlight', function (voxelPos) {
+    console.log("highlighted voxel: " + voxelPos)
+    game.setBlock(voxelPos, currentMaterial) // paint mode
+  })
 
   // toggle between first and third person modes
   window.addEventListener('keydown', function (ev) {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "url": "git@github.com:maxogden/voxel-hello-world.git"
   },
   "dependencies": {
+    "voxel": "0.3.1",
     "voxel-engine": "0.10.0",
-    "voxel-highlight": "0.0.5",
+    "voxel-highlight": "0.0.6",
     "voxel-player": "0.1.0",
     "painterly-textures": "0.0.3",
     "toolbar": "0.0.5",


### PR DESCRIPTION
Now using voxel-highlight 0.0.6 which passes a useful voxel position array to listeners.

As a demo, using that array to paint the highlighted voxel with the currently selected material (using setBlock).

Note that frequency is set to very fast (20ms) which may cause performance issues on slower systems.
