### PR TITLE
0.0.6: added highlight 007 usage with block place preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxel-hello-world",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "repository": {
     "type":"git",
     "url": "git@github.com:maxogden/voxel-hello-world.git"
@@ -8,7 +8,7 @@
   "dependencies": {
     "voxel": "0.3.1",
     "voxel-engine": "0.10.0",
-    "voxel-highlight": "0.0.6",
+    "voxel-highlight": "0.0.7",
     "voxel-player": "0.1.0",
     "painterly-textures": "0.0.3",
     "toolbar": "0.0.5",


### PR DESCRIPTION
bumped version to 0.0.6

block erase and place now use highlight data passed by callbacks

block placement position is highlighted as empty wireframe when control key is pressed

![highlight_adjacent](https://f.cloud.github.com/assets/768409/241439/232171ce-89ae-11e2-913c-25ca9afd0baa.png)
