### PR TITLE
now passing highlightOpts from game opts to voxel-highlight

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,7 @@ module.exports = function(opts) {
 
   // highlight blocks when you look at them, hold <Ctrl> for block placement
   var blockPosPlace, blockPosErase
-  var hl = game.highlighter = highlight(game, {
-    color: 0x00ff00,
-    distance: 20,
-    adjacentAnimate: true
-  })
+  var hl = game.highlighter = highlight(game, opts.highlightOpts || { color: 0xff0000 })
   hl.on('highlight', function (voxelPos) { blockPosErase = voxelPos })
   hl.on('remove', function (voxelPos) { blockPosErase = null })
   hl.on('highlight-adjacent', function (voxelPos) { blockPosPlace = voxelPos })


### PR DESCRIPTION
now hello-world clients like test.js can pass highlight options along with other game options, like this:

```
var opts = {
  highlightOpts: {
    color: 0xffff00,
    distance: 100,
    animate: true
  },
  generate: function (x, y, z) {
    return y % 16 ? 0 : Math.ceil(Math.random() * 2)
  }
}

var game = require('voxel-hello-world')(opts)
```
